### PR TITLE
Fix: Allow regexes

### DIFF
--- a/wp_parser/wp_chat.py
+++ b/wp_parser/wp_chat.py
@@ -231,7 +231,7 @@ def main():
         c.set_root(c.senders[int(raw_input("Please choose one person to be the root: "))])
     else:
         c.set_root(args["root"])
-    c.all_features()
+    c.all_features(pattern_list=args['regexes'])
     c.print_features()
     c.save_features(args["output"])
 


### PR DESCRIPTION
Regexes were not coming through when passing the `-r` flag. Now they do.

If I'm missing something and the `-r` flag actually does work currently, my bad.  I couldn't get it to work without this modification, and possibly there's a modification that is more in line with the flow of the code.

Thanks for putting out a helpful tool!